### PR TITLE
Prevent deaths on Sote maze proc tick

### DIFF
--- a/src/main/java/io/blert/challenges/tob/rooms/RoomDataTracker.java
+++ b/src/main/java/io/blert/challenges/tob/rooms/RoomDataTracker.java
@@ -260,8 +260,6 @@ public abstract class RoomDataTracker extends DataTracker implements EventHandle
             if (!raider.isActive() && raider.isAlive()) {
                 // Disconnecting during a ToB room is considered a death.
                 raider.setDead(tick);
-                WorldPoint deathPoint = raider.getPlayer() != null ? getWorldLocation(raider.getPlayer()) : null;
-                dispatchEvent(new PlayerDeathEvent(getStage(), tick, deathPoint, raider.getUsername()));
             }
         });
 
@@ -276,15 +274,8 @@ public abstract class RoomDataTracker extends DataTracker implements EventHandle
 
             // ToB orb health. 0 = hide, 1-27 = health percentage (0-100%), 30 = dead.
             int orbHealth = client.getVarbitValue(Varbits.THEATRE_OF_BLOOD_ORB1 + orb);
-            if (orbHealth == 30) {
-                if (raider.isDead()) {
-                    return;
-                }
-
+            if (orbHealth == 30 && !raider.isDead()) {
                 raider.setDead(tick);
-                if (raider.getPlayer() != null) {
-                    dispatchEvent(new PlayerDeathEvent(getStage(), tick, null, raider.getUsername()));
-                }
             }
         });
     }

--- a/src/main/java/io/blert/challenges/tob/rooms/sotetseg/SotetsegDataTracker.java
+++ b/src/main/java/io/blert/challenges/tob/rooms/sotetseg/SotetsegDataTracker.java
@@ -67,6 +67,7 @@ public class SotetsegDataTracker extends RoomDataTracker {
     boolean inMaze = false;
     boolean isUnder = false;
     private String chosenPlayer = null;
+    private int invulnerableUntilTick = -1;
     private final Set<GroundObject> activeMazeTiles = new HashSet<>();
 
     public SotetsegDataTracker(TheatreChallenge manager, Client client) {
@@ -93,6 +94,15 @@ public class SotetsegDataTracker extends RoomDataTracker {
     protected void onTick() {
         super.onTick();
         final int tick = getTick();
+
+        if (invulnerableUntilTick != -1 && tick >= invulnerableUntilTick) {
+            for (Raider raider : theatreChallenge.getParty()) {
+                if (raider.isAlive()) {
+                    raider.setInvulnerable(false);
+                }
+            }
+            invulnerableUntilTick = -1;
+        }
 
         Player deathBallTarget = checkForDeathBall();
 
@@ -221,6 +231,20 @@ public class SotetsegDataTracker extends RoomDataTracker {
         }
 
         if (!inMaze) {
+            // If a player dies on the tick the maze procs, they will be saved,
+            // but the death event will still fire. Prevent the death from being
+            // processed on this tick and several after in case orbs varbits do
+            // something weird. Also, clear any deaths occurring on this tick
+            // in case that event fired first.
+            invulnerableUntilTick = tick + 4;
+            for (Raider raider : theatreChallenge.getParty()) {
+                if (raider.getDeathTick() == tick) {
+                    raider.setAlive();
+                }
+                if (raider.isAlive()) {
+                    raider.setInvulnerable(true);
+                }
+            }
             startMaze(tick);
         }
     }

--- a/src/main/java/io/blert/core/DataTracker.java
+++ b/src/main/java/io/blert/core/DataTracker.java
@@ -124,8 +124,15 @@ public abstract class DataTracker implements RuneliteEventHandler {
             log.error("Error during onTick for stage {}", stage, e);
         }
 
-        // Send out an update for every tracked NPC. This must be done after `onTick` to ensure any
-        // implementation-specific changes to the NPC are complete.
+        // Send out an update for every tracked NPC and commit player death events.
+        // This must be done after `onTick` to ensure any implementation-specific changes are complete.
+        for (Raider raider : challenge.getParty()) {
+            if (raider.getDeathTick() == getTick()) {
+                Player player = raider.getPlayer();
+                WorldPoint location = player != null ? getWorldLocation(player) : null;
+                dispatchEvent(new PlayerDeathEvent(getStage(), getTick(), location, raider.getUsername()));
+            }
+        }
         trackedNpcs.forEach(this::sendNpcUpdate);
     }
 
@@ -881,10 +888,7 @@ public abstract class DataTracker implements RuneliteEventHandler {
         if (event.getActor() instanceof Player) {
             Raider raider = challenge.getRaider(event.getActor().getName());
             if (raider != null) {
-                int tick = getTick();
-                raider.setDead(tick);
-                dispatchEvent(new PlayerDeathEvent(
-                        getStage(), tick, getWorldLocation(event.getActor()), raider.getUsername()));
+                raider.setDead(getTick());
             }
         }
 

--- a/src/main/java/io/blert/core/Raider.java
+++ b/src/main/java/io/blert/core/Raider.java
@@ -70,6 +70,8 @@ public class Raider {
     private boolean dead;
     @Getter
     private int deathTick;
+    @Setter
+    private boolean invulnerable;
 
     private BlowpipeState blowpiping = BlowpipeState.NOT_PIPING;
 
@@ -117,8 +119,15 @@ public class Raider {
     }
 
     public void setDead(int tick) {
-        this.dead = true;
-        this.deathTick = tick;
+        if (!invulnerable) {
+            this.dead = true;
+            this.deathTick = tick;
+        }
+    }
+
+    public void setAlive() {
+        this.dead = false;
+        this.deathTick = -1;
     }
 
     public boolean isOffCooldownOn(int tick) {
@@ -131,6 +140,7 @@ public class Raider {
     public void resetForNewRoom() {
         dead = false;
         deathTick = -1;
+        invulnerable = false;
         blowpiping = BlowpipeState.NOT_PIPING;
         equipment = new Item[EquipmentSlot.values().length];
         equipmentChangesThisTick.clear();


### PR DESCRIPTION
Players who die on the same tick as the maze procs are saved by the teleport, but since their HP still hits 0 on that tick the ActorDeath event fires. This updates the Sote tracker to prevent deaths from being registered on a proc by marking players as invulnerable on that tick and the duration of the teleport animation.