### PR TITLE
Fix Verzik despawn timing

### DIFF
--- a/src/main/java/io/blert/challenges/tob/TobNpc.java
+++ b/src/main/java/io/blert/challenges/tob/TobNpc.java
@@ -157,10 +157,15 @@ public enum TobNpc {
     VERZIK_P2_REGULAR(NpcID.VERZIK_PHASE2, 2, ChallengeMode.TOB_REGULAR, new int[]{2437, 2843, 3250}),
     VERZIK_P2_HARD(NpcID.VERZIK_PHASE2_HARD, 2, ChallengeMode.TOB_HARD, new int[]{2437, 2843, 3250}),
 
-    // Verzik P3, including death animation.
-    VERZIK_P3_ENTRY(NpcID.VERZIK_PHASE3_STORY, 2, ChallengeMode.TOB_ENTRY, 320),
-    VERZIK_P3_REGULAR(NpcID.VERZIK_PHASE3, 2, ChallengeMode.TOB_REGULAR, new int[]{2437, 2843, 3250}),
-    VERZIK_P3_HARD(NpcID.VERZIK_PHASE3_HARD, 2, ChallengeMode.TOB_HARD, new int[]{2437, 2843, 3250}),
+    // Verzik P3.
+    VERZIK_P3_ENTRY(NpcID.VERZIK_PHASE3_STORY, 1, ChallengeMode.TOB_ENTRY, 320),
+    VERZIK_P3_REGULAR(NpcID.VERZIK_PHASE3, 1, ChallengeMode.TOB_REGULAR, new int[]{2437, 2843, 3250}),
+    VERZIK_P3_HARD(NpcID.VERZIK_PHASE3_HARD, 1, ChallengeMode.TOB_HARD, new int[]{2437, 2843, 3250}),
+
+    // Verzik death animation.
+    VERZIK_DEATH_ENTRY(NpcID.VERZIK_DEATH_BAT_STORY, 1, ChallengeMode.TOB_ENTRY, 0),
+    VERZIK_DEATH_REGULAR(NpcID.VERZIK_DEATH_BAT, 1, ChallengeMode.TOB_REGULAR, 0),
+    VERZIK_DEATH_HARD(NpcID.VERZIK_DEATH_BAT_HARD, 1, ChallengeMode.TOB_HARD, 0),
 
     // Pillars at Verzik.
     VERZIK_PILLAR(NpcID.VERZIK_PILLAR_NPC, 1, ChallengeMode.NO_MODE, 0),
@@ -406,8 +411,17 @@ public enum TobNpc {
         return isVerzikP3(this.id);
     }
 
+    public static boolean isVerzikDeath(int id) {
+        return idMatches(id, VERZIK_DEATH_ENTRY, VERZIK_DEATH_REGULAR, VERZIK_DEATH_HARD);
+    }
+
+    public boolean isVerzikDeath() {
+        return isVerzikDeath(this.id);
+    }
+
     public static boolean isAnyVerzik(int id) {
-        return isVerzikIdle(id) || isVerzikP1(id) || isVerzikP1Transition(id) || isVerzikP2(id) || isVerzikP3(id);
+        return isVerzikIdle(id) || isVerzikP1(id) || isVerzikP1Transition(id)
+                || isVerzikP2(id) || isVerzikP3(id) || isVerzikDeath(id);
     }
 
     public boolean isAnyVerzik() {

--- a/src/main/java/io/blert/challenges/tob/rooms/verzik/VerzikDataTracker.java
+++ b/src/main/java/io/blert/challenges/tob/rooms/verzik/VerzikDataTracker.java
@@ -253,6 +253,10 @@ public class VerzikDataTracker extends RoomDataTracker {
             dispatchEvent(new VerzikRedsSpawnEvent(tick));
         }
 
+        if (verzik == null) {
+            return;
+        }
+
         if (tick == nextVerzikAttackTick - 1) {
             if (phase == VerzikPhase.P2) {
                 checkForBounceChances();
@@ -289,7 +293,7 @@ public class VerzikDataTracker extends RoomDataTracker {
             dispatchEvent(new VerzikYellowsEvent(tick, new ArrayList<>(currentYellows)));
         }
 
-        if (tick > phaseStartTick + 5 && verzik != null) {
+        if (tick > phaseStartTick + 5) {
             // After the phase has been active for several ticks, re-enable varbit updates.
             verzik.setDisableVarbitUpdates(false);
         }
@@ -402,8 +406,9 @@ public class VerzikDataTracker extends RoomDataTracker {
             dispatchEvent(new VerzikPhaseEvent(tick, VerzikPhase.P2));
         }
 
-        // Verzik despawns between phases, but it should not be counted as a final despawn until the end of the fight.
-        return trackedNpc == verzik && phase == VerzikPhase.P3;
+        // Verzik despawns between phases, but it should not be counted.
+        // Her final despawn is sent when she changes to her death ID.
+        return false;
     }
 
     @Override
@@ -429,6 +434,12 @@ public class VerzikDataTracker extends RoomDataTracker {
 
             // A transition from P1 to P2 does not spawn a new NPC. Simply reset Verzik's HP to its P2 value.
             verzik.setHitpoints(new Hitpoints(tobNpc, theatreChallenge.getScale()));
+        }
+
+        if (TobNpc.isVerzikP3(beforeId) && tobNpc.isVerzikDeath() && verzik != null) {
+            despawnTrackedNpc(verzik);
+            verzik = null;
+            phase = VerzikPhase.IDLE;
         }
     }
 

--- a/src/main/java/io/blert/core/DataTracker.java
+++ b/src/main/java/io/blert/core/DataTracker.java
@@ -720,12 +720,6 @@ public abstract class DataTracker implements RuneliteEventHandler {
         }
         trackedNpcs.add(trackedNpc);
 
-        if (notStarted()) {
-            // NPCs which spawn before the room begins must be reported immediately as the `onTick` handler
-            // is not yet active.
-            dispatchEvent(NpcEvent.spawn(getStage(), 0, getWorldLocation(trackedNpc), trackedNpc));
-        }
-
         challenge.updateMode(trackedNpc.getMode());
     }
 

--- a/src/main/java/io/blert/core/Raider.java
+++ b/src/main/java/io/blert/core/Raider.java
@@ -291,6 +291,8 @@ public class Raider {
 
         if (spell.isStall()) {
             activeStall = Pair.of(tick, spell);
+            animationId = -1;
+            animationTick = tick;
         }
 
         activeSpells.put(spell.getId(), tick + spell.getCooldown(matchedGraphicId));


### PR DESCRIPTION
The previous condition for Verzik despawn fired on any Verzik NPC ID that despawned while P3 was active. This included the P2 NPC despawning, since P3 is already active at that point. This resulted in a spurious Verzik despawn + new P3 spawn with the same room ID, which silently worked under the existing system, but was caught by the new stricter merging system's checks.

This change removes the spurious despawn and updates the offical Verzik despawn to fire once she transitions from the end of her P3 death animation to a bat flying away.

Additionally, removes direct pre-room spawn event dispatch. This was added very early when spawn events were only fired from the Runelite NPC spawn handler. The data tracker has long since been refactored to fire spawn events in its tick handler on the tick that an NPC spawns, so having the pre-room event set a spawn tick of 0 was sufficient, and again resulted in duplicate spawn events being fired.