### PR TITLE
Always set an attack tick for bounce events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'io.blert'
-version = '0.9.6'
+version = '0.9.10'
 
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()

--- a/src/main/java/io/blert/events/tob/VerzikBounceEvent.java
+++ b/src/main/java/io/blert/events/tob/VerzikBounceEvent.java
@@ -70,7 +70,7 @@ public class VerzikBounceEvent extends TobEvent {
      */
     public VerzikBounceEvent(int tick, int playersInRange, int playersNotInRange) {
         super(EventType.VERZIK_BOUNCE, Room.VERZIK, tick, null);
-        this.attackTick = -1;
+        this.attackTick = tick;
         this.playersInRange = playersInRange;
         this.playersNotInRange = playersNotInRange;
         this.bouncedPlayer = null;


### PR DESCRIPTION
Verzik bounce events are sent both when a player was actually bounced (with the player's name) and on every non bounce Verzik attack (to track bounce chances). The latter case did not previously set a referenced Verzik attack tick; this ensures that the event always has one.