### PR TITLE
Don't send Sotetseg death in mazes

### DIFF
--- a/src/main/java/io/blert/challenges/tob/rooms/sotetseg/SotetsegDataTracker.java
+++ b/src/main/java/io/blert/challenges/tob/rooms/sotetseg/SotetsegDataTracker.java
@@ -159,7 +159,9 @@ public class SotetsegDataTracker extends RoomDataTracker {
             }
 
             if (isUnder && playerLocation.inSotetsegOverworld()) {
-                finishMaze(tick);
+                if (sotetseg != null && !TobNpc.isSotetsegIdle(sotetseg.getNpcId())) {
+                    finishMaze(tick);
+                }
             }
         }
     }
@@ -187,7 +189,10 @@ public class SotetsegDataTracker extends RoomDataTracker {
             if (sotetseg.getNpc().isDead()) {
                 sotetseg = null;
             }
-            return true;
+            // If the local player is sent to the underworld, Sotetseg disappears
+            // from their client, creating a false despawn event. Ignore despawns
+            // during maze phases.
+            return !inMaze;
         }
         return false;
     }
@@ -332,6 +337,10 @@ public class SotetsegDataTracker extends RoomDataTracker {
     }
 
     private void finishMaze(int tick) {
+        if (!inMaze) {
+            return;
+        }
+
         inMaze = false;
         isUnder = false;
         mazeTracker.finishMaze();


### PR DESCRIPTION
If the local player gets teleported to the underworld, Sotetseg is no longer visible in their client, resulting in a despawn event. This prevents the plugin from sending an NPC_DEATH for Sotetseg during mazes, only once the boss actually dies. Additionally, when returning from the underworld, does not immediately end maze phase but waits for Sotetseg to become active.