### PR TITLE
Snapshot player equipment on change events

### DIFF
--- a/src/main/java/io/blert/BlertPlugin.java
+++ b/src/main/java/io/blert/BlertPlugin.java
@@ -42,11 +42,11 @@ import net.runelite.api.GameState;
 import net.runelite.api.WorldType;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.*;
-import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
@@ -303,7 +303,14 @@ public class BlertPlugin extends Plugin {
         }
     }
 
-    @Subscribe
+    @Subscribe(priority = 111)  // Run before other plugins mutate player state
+    private void onPlayerChanged(PlayerChanged event) {
+        if (activeChallenge != null) {
+            activeChallenge.onPlayerChanged(event);
+        }
+    }
+
+    @Subscribe(priority = 111)  // Run before other plugins mutate player state
     private void onAnimationChanged(AnimationChanged event) {
         if (activeChallenge != null) {
             activeChallenge.onAnimationChanged(event);

--- a/src/main/java/io/blert/core/DataTracker.java
+++ b/src/main/java/io/blert/core/DataTracker.java
@@ -194,6 +194,15 @@ public abstract class DataTracker implements RuneliteEventHandler {
     }
 
     /**
+     * Implementation-specific equivalent of the {@code onPlayerChanged} Runelite event handler.
+     * Should be overriden by implementations which require special handling.
+     *
+     * @param event The event.
+     */
+    protected void onPlayerChange(PlayerChanged event) {
+    }
+
+    /**
      * Implementation-specific equivalent of the {@code onAnimationChanged} Runelite event handler.
      * Should be overriden by implementations which require special animation tracking.
      *
@@ -770,6 +779,13 @@ public abstract class DataTracker implements RuneliteEventHandler {
     public final void onNpcChanged(NpcChanged event) {
         if (!terminating()) {
             onNpcChange(event);
+        }
+    }
+
+    @Override
+    public final void onPlayerChanged(PlayerChanged event) {
+        if (!terminating()) {
+            onPlayerChange(event);
         }
     }
 

--- a/src/main/java/io/blert/core/Item.java
+++ b/src/main/java/io/blert/core/Item.java
@@ -31,4 +31,9 @@ import lombok.Getter;
 public class Item {
     private int id;
     private int quantity;
+
+    @Override
+    public String toString() {
+        return "Item{id=" + id + ", quantity=" + quantity + '}';
+    }
 }

--- a/src/main/java/io/blert/core/Raider.java
+++ b/src/main/java/io/blert/core/Raider.java
@@ -76,6 +76,7 @@ public class Raider {
     private BlowpipeState blowpiping = BlowpipeState.NOT_PIPING;
 
     private Item[] equipment = new Item[EquipmentSlot.values().length];
+    private Item[] pendingEquipment = null;
     @Getter
     private final List<ItemDelta> equipmentChangesThisTick = new ArrayList<>();
 
@@ -143,6 +144,7 @@ public class Raider {
         invulnerable = false;
         blowpiping = BlowpipeState.NOT_PIPING;
         equipment = new Item[EquipmentSlot.values().length];
+        // Don't reset pending equipment as it challenge-level.
         equipmentChangesThisTick.clear();
         animationId = -1;
         animationTick = 0;
@@ -209,13 +211,7 @@ public class Raider {
             graphicsIds.put(spotAnim.getId(), spotAnim);
         }
 
-        equipmentChangesThisTick.clear();
-
-        if (localPlayer) {
-            updateEquipmentFromLocalPlayer(client);
-        } else {
-            updateEquipmentFromVisibleItems(client);
-        }
+        updateEquipment(client);
 
         Item newWeapon = equipment[EquipmentSlot.WEAPON.ordinal()];
 
@@ -311,6 +307,37 @@ public class Raider {
         }
     }
 
+    public void snapshotEquipmentChanges(Client client, PlayerComposition composition) {
+        pendingEquipment = snapshotFromComposition(client, composition);
+    }
+
+    private Item[] snapshotFromComposition(Client client,
+                                           PlayerComposition composition) {
+        Item[] snapshot = new Item[EquipmentSlot.values().length];
+        Arrays.stream(EquipmentSlot.values()).filter(slot -> slot.getKitType() != null).forEach(slot -> {
+            int id = composition.getEquipmentId(slot.getKitType());
+            if (id != -1) {
+                var comp = client.getItemDefinition(id);
+                snapshot[slot.ordinal()] = new Item(comp.getId(), 1);
+            } else {
+                snapshot[slot.ordinal()] = null;
+            }
+        });
+        return snapshot;
+    }
+
+    private void updateEquipment(Client client) {
+        equipmentChangesThisTick.clear();
+
+        if (localPlayer) {
+            updateEquipmentFromLocalPlayer(client);
+        } else {
+            updateEquipmentFromVisibleItems(client);
+        }
+
+        pendingEquipment = null;
+    }
+
     private void updateEquipmentFromLocalPlayer(Client client) {
         var equippedItems = client.getItemContainer(InventoryID.EQUIPMENT);
         if (equippedItems == null) {
@@ -355,16 +382,27 @@ public class Raider {
     }
 
     private void updateEquipmentFromVisibleItems(Client client) {
+        Item[] items;
+        if (pendingEquipment != null) {
+            items = pendingEquipment;
+        } else {
+            // Fall back to reading the composition iff no equipment events
+            // have been received and the current equipment is uninitialized.
+            if (Arrays.stream(equipment).allMatch(Objects::isNull)) {
+                items = snapshotFromComposition(client, Objects.requireNonNull(player).getPlayerComposition());
+            } else {
+                return;
+            }
+        }
+
         Arrays.stream(EquipmentSlot.values()).filter(slot -> slot.getKitType() != null).forEach(slot -> {
             Item previous = equipment[slot.ordinal()];
+            Item current = items[slot.ordinal()];
 
-            int id = Objects.requireNonNull(player).getPlayerComposition().getEquipmentId(slot.getKitType());
-            if (id != -1) {
-                var comp = client.getItemDefinition(id);
-
-                if (previous == null || previous.getId() != comp.getId()) {
-                    equipmentChangesThisTick.add(new ItemDelta(comp.getId(), 1, slot.ordinal(), true));
-                    equipment[slot.ordinal()] = new Item(comp.getId(), 1);
+            if (current != null) {
+                if (previous == null || previous.getId() != current.getId()) {
+                    equipmentChangesThisTick.add(new ItemDelta(current.getId(), 1, slot.ordinal(), true));
+                    equipment[slot.ordinal()] = current;
                 }
             } else if (previous != null) {
                 equipmentChangesThisTick.add(new ItemDelta(previous.getId(), previous.getQuantity(), slot.ordinal(), false));

--- a/src/main/java/io/blert/core/RecordableChallenge.java
+++ b/src/main/java/io/blert/core/RecordableChallenge.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Player;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.*;
 import net.runelite.client.callback.ClientThread;
@@ -64,7 +65,7 @@ public abstract class RecordableChallenge implements RuneliteEventHandler {
     @Getter
     private ChallengeState state = ChallengeState.INACTIVE;
 
-    private List<CompletableFuture<Status>> statusUpdateFutures = new ArrayList<>();
+    private final List<CompletableFuture<Status>> statusUpdateFutures = new ArrayList<>();
 
     @Getter
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -307,6 +308,22 @@ public abstract class RecordableChallenge implements RuneliteEventHandler {
         DataTracker tracker = getActiveTracker();
         if (tracker != null) {
             tracker.onNpcChanged(event);
+        }
+    }
+
+    @Override
+    public void onPlayerChanged(PlayerChanged event) {
+        // Bypass the data tracker for equipment snapshots to catch changes
+        // occurring between stages.
+        Player player = event.getPlayer();
+        Raider raider = getRaider(player.getName());
+        if (raider != null) {
+            raider.snapshotEquipmentChanges(client, player.getPlayerComposition());
+        }
+
+        DataTracker tracker = getActiveTracker();
+        if (tracker != null) {
+            tracker.onPlayerChanged(event);
         }
     }
 

--- a/src/main/java/io/blert/core/RuneliteEventHandler.java
+++ b/src/main/java/io/blert/core/RuneliteEventHandler.java
@@ -33,6 +33,7 @@ public interface RuneliteEventHandler {
     default void onNpcSpawned(NpcSpawned event) {}
     default void onNpcDespawned(NpcDespawned event) {}
     default void onNpcChanged(NpcChanged event) {}
+    default void onPlayerChanged(PlayerChanged event) {}
     default void onAnimationChanged(AnimationChanged event) {}
     default void onProjectileMoved(ProjectileMoved event) {}
     default void onChatMessage(ChatMessage event) {}


### PR DESCRIPTION
Data trackers read player gear every tick in their onTick handler. For non-local players, this is done via the player object's composition. This composition object is shared across plugins and mutable. Since onTick always runs last, other plugins might have changed the gear in the composition, resulting in the wrong items being captured.

This updates the plugin to subscribe to PlayerChanged events at a high priority to intercept and snapshot the original composition before any plugin can modify it, then use that during the tick updates.