### PR TITLE
Send explicit snapshot as the first player update

### DIFF
--- a/src/main/java/io/blert/core/Raider.java
+++ b/src/main/java/io/blert/core/Raider.java
@@ -65,6 +65,9 @@ public class Raider {
     @Getter
     @Setter
     private boolean active;
+    private int lastUpdateTick = Integer.MIN_VALUE;
+    @Getter
+    private boolean snapshot;
 
     @Getter
     private boolean dead;
@@ -139,6 +142,8 @@ public class Raider {
      * Resets the player's state to what it should be on entry to a new room in the raid.
      */
     public void resetForNewRoom() {
+        lastUpdateTick = Integer.MIN_VALUE;
+        snapshot = true;
         dead = false;
         deathTick = -1;
         invulnerable = false;
@@ -211,7 +216,7 @@ public class Raider {
             graphicsIds.put(spotAnim.getId(), spotAnim);
         }
 
-        updateEquipment(client);
+        updateEquipment(client, tick);
 
         Item newWeapon = equipment[EquipmentSlot.WEAPON.ordinal()];
 
@@ -231,6 +236,8 @@ public class Raider {
                 blowpiping = BlowpipeState.STOPPED_PIPING;
             }
         }
+
+        lastUpdateTick = tick;
     }
 
     public void recordAttack(int tick, @NonNull AttackDefinition attack, boolean ignoreCooldown) {
@@ -313,21 +320,26 @@ public class Raider {
 
     private Item[] snapshotFromComposition(Client client,
                                            PlayerComposition composition) {
-        Item[] snapshot = new Item[EquipmentSlot.values().length];
+        Item[] gearSnapshot = new Item[EquipmentSlot.values().length];
         Arrays.stream(EquipmentSlot.values()).filter(slot -> slot.getKitType() != null).forEach(slot -> {
             int id = composition.getEquipmentId(slot.getKitType());
             if (id != -1) {
                 var comp = client.getItemDefinition(id);
-                snapshot[slot.ordinal()] = new Item(comp.getId(), 1);
+                gearSnapshot[slot.ordinal()] = new Item(comp.getId(), 1);
             } else {
-                snapshot[slot.ordinal()] = null;
+                gearSnapshot[slot.ordinal()] = null;
             }
         });
-        return snapshot;
+        return gearSnapshot;
     }
 
-    private void updateEquipment(Client client) {
+    private void updateEquipment(Client client, int tick) {
         equipmentChangesThisTick.clear();
+
+        snapshot = lastUpdateTick != tick - 1;
+        if (snapshot) {
+            equipment = new Item[EquipmentSlot.values().length];
+        }
 
         if (localPlayer) {
             updateEquipmentFromLocalPlayer(client);

--- a/src/main/java/io/blert/events/PlayerUpdateEvent.java
+++ b/src/main/java/io/blert/events/PlayerUpdateEvent.java
@@ -67,6 +67,9 @@ public class PlayerUpdateEvent extends Event {
     private @Nullable PrayerSet activePrayers = null;
 
     @Getter
+    private final boolean snapshot;
+
+    @Getter
     private List<ItemDelta> equipmentChangesThisTick;
     @Getter
     private int offCooldownTick = 0;
@@ -83,7 +86,8 @@ public class PlayerUpdateEvent extends Event {
     public static PlayerUpdateEvent fromRaider(Stage stage, int tick, WorldPoint point, Client client, Raider raider) {
         Source source = raider.isLocalPlayer() ? Source.PRIMARY : Source.SECONDARY;
 
-        PlayerUpdateEvent evt = new PlayerUpdateEvent(stage, tick, point, source, raider.getUsername());
+        PlayerUpdateEvent evt = new PlayerUpdateEvent(stage, tick, point,
+                source, raider.getUsername(), raider.isSnapshot());
         evt.equipmentChangesThisTick = raider.getEquipmentChangesThisTick();
         evt.offCooldownTick = raider.getOffCooldownTick();
 
@@ -123,10 +127,12 @@ public class PlayerUpdateEvent extends Event {
     }
 
 
-    private PlayerUpdateEvent(Stage stage, int tick, WorldPoint point, Source source, String username) {
+    private PlayerUpdateEvent(Stage stage, int tick, WorldPoint point,
+                              Source source, String username, boolean snapshot) {
         super(EventType.PLAYER_UPDATE, stage, tick, point);
         this.source = source;
         this.username = username;
+        this.snapshot = snapshot;
     }
 
     /**

--- a/src/main/java/io/blert/json/Event.java
+++ b/src/main/java/io/blert/json/Event.java
@@ -97,7 +97,7 @@ public class Event {
         public List<Long> equipmentDeltas;
         public Long activePrayers;
         public int dataSource;
-        public Integer partyIndex;
+        public Boolean snapshot;
 
         public static class EquippedItem {
             public int slot;

--- a/src/main/java/io/blert/json/JsonEventTranslator.java
+++ b/src/main/java/io/blert/json/JsonEventTranslator.java
@@ -80,6 +80,10 @@ public class JsonEventTranslator {
                 player.name = playerUpdateEvent.getUsername();
                 player.offCooldownTick = playerUpdateEvent.getOffCooldownTick();
 
+                if (playerUpdateEvent.isSnapshot()) {
+                    player.snapshot = true;
+                }
+
                 playerUpdateEvent.getHitpoints().ifPresent(sl -> player.hitpoints = sl.getValue());
                 playerUpdateEvent.getPrayer().ifPresent(sl -> player.prayer = sl.getValue());
                 playerUpdateEvent.getAttack().ifPresent(sl -> player.attack = sl.getValue());


### PR DESCRIPTION
The new `snapshot` flag in PLAYER_UPDATE events indicates that the event contains a full delta against a previous null state. This matters at the start of a new local challenge when raider objects are first initialized to distinguish them from regular delta updates, in case the client had been previously streaming events from the same challenge.

The code generalizes this to send snapshots on any tick discontinuity, though that is purely defensive; the first is the only important one.