### PR TITLE
Stop sending Verzik attack events after wipes

### DIFF
--- a/src/main/java/io/blert/BlertPlugin.java
+++ b/src/main/java/io/blert/BlertPlugin.java
@@ -44,7 +44,6 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
@@ -69,9 +68,6 @@ public class BlertPlugin extends Plugin {
 
     @Inject
     private ClientThread clientThread;
-
-    @Inject
-    private EventBus eventBus;
 
     @Inject
     private ClientToolbar clientToolbar;

--- a/src/main/java/io/blert/challenges/tob/rooms/verzik/VerzikDataTracker.java
+++ b/src/main/java/io/blert/challenges/tob/rooms/verzik/VerzikDataTracker.java
@@ -661,7 +661,29 @@ public class VerzikDataTracker extends RoomDataTracker {
         }
     }
 
+    private void sendMeleeIfChanced(int tick) {
+        if (unidentifiedVerzikAttackTick != -1) {
+            // No projectiles were recorded since the last Verzik
+            // attack. Check if it could have been a melee attack.
+            if (p3MeleeChanceTicks.contains(unidentifiedVerzikAttackTick)) {
+                dispatchEvent(new VerzikAttackStyleEvent(
+                        tick, VerzikAttackStyleEvent.Style.MELEE, unidentifiedVerzikAttackTick));
+            }
+            unidentifiedVerzikAttackTick = -1;
+        }
+    }
+
     private void handleVerzikAttack(int tick) {
+        var party = getChallenge().getParty();
+        if (!party.isEmpty() && party.stream().allMatch(Raider::isDead)) {
+            // Verzik attacks are inferred purely from tick cadence rather than
+            // animations. Stop sending them if every player has died.
+            if (phase == VerzikPhase.P3) {
+                sendMeleeIfChanced(tick);
+            }
+            return;
+        }
+
         Player target = null;
 
         switch (phase) {
@@ -703,15 +725,7 @@ public class VerzikDataTracker extends RoomDataTracker {
                 break;
 
             case P3:
-                if (unidentifiedVerzikAttackTick != -1) {
-                    // No projectiles were recorded since the last Verzik
-                    // attack. Check if it could have been a melee attack.
-                    if (p3MeleeChanceTicks.contains(unidentifiedVerzikAttackTick)) {
-                        dispatchEvent(new VerzikAttackStyleEvent(
-                                tick, VerzikAttackStyleEvent.Style.MELEE, unidentifiedVerzikAttackTick));
-                    }
-                    unidentifiedVerzikAttackTick = -1;
-                }
+                sendMeleeIfChanced(tick);
 
                 if (verzikAttacksUntilSpecial == 0) {
                     verzikAttacksUntilSpecial = P3_ATTACKS_BEFORE_SPECIAL;


### PR DESCRIPTION
Verzik P3's attacks are inferred using a tick cadence because their animations are masked in APIs. This updates Verzik's attack tracker to stop this cadence if the entire party dies to avoid any spurious attacks while the raid cleans up afer a wipe.