### PR TITLE
Only emit stall events at room cap

### DIFF
--- a/src/main/java/io/blert/challenges/tob/rooms/nylocas/NylocasDataTracker.java
+++ b/src/main/java/io/blert/challenges/tob/rooms/nylocas/NylocasDataTracker.java
@@ -118,8 +118,12 @@ public class NylocasDataTracker extends RoomDataTracker {
             // it means that the next wave did not spawn when expected, i.e. a stall occurred.
             nextWaveSpawnCheckTick += WAVE_TICK_CYCLE;
 
-            log.debug("Stalled wave {} ({}/{})", currentWave, roomNyloCount(), waveCap());
-            dispatchEvent(NyloWaveEvent.stall(tick, currentWave, roomNyloCount(), waveCap()));
+            // A stall only happens when the room is at the nylo cap; avoid
+            // emitting phantom stall events if under it.
+            if (roomNyloCount() >= waveCap()) {
+                log.debug("Stalled wave {} ({}/{})", currentWave, roomNyloCount(), waveCap());
+                dispatchEvent(NyloWaveEvent.stall(tick, currentWave, roomNyloCount(), waveCap()));
+            }
         }
 
         nylosInRoom.values().stream()


### PR DESCRIPTION
Updates the Nylo tracker to count nylos in the room before sending a stall event to avoid phantom stalls if a wave spawn was not identified.